### PR TITLE
Add `cjs`

### DIFF
--- a/text-extensions.json
+++ b/text-extensions.json
@@ -32,6 +32,7 @@
 	"cfm",
 	"cfml",
 	"cgi",
+	"cjs",
 	"clj",
 	"cljs",
 	"cls",


### PR DESCRIPTION
Thanks for this package, it's proven very useful 🙂

I did notice that `cjs` was missing from the file extensions (yet `mjs`, `js`, `ts` are there), so here's a PR for that.